### PR TITLE
Fix stylized plugin name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # syncopate
 
-**Syn**tax **cop**y-**pa**s**te**.
+(**Syn**)tax (**cop**)y-p(**a**)s(**te**).
 
 ## What's it for?
 


### PR DESCRIPTION
Apparently vim's pandoc plugin renders markdown somewhat differently
than github does.  The original version showed confusing asterisks, and
was generally hideous.
