### PR TITLE
Save and restore 'background'

### DIFF
--- a/autoload/syncopate.vim
+++ b/autoload/syncopate.vim
@@ -27,7 +27,7 @@ function! s:SyncopateSaveAndChangeSettings()
   " Save any settings we'll need to restore later.
   let l:setting_names = []
   if l:change_colorscheme
-    call extend(l:setting_names, ['g:colors_name'])
+    call extend(l:setting_names, ['&background', 'g:colors_name'])
   endif
   let l:settings = maktaba#value#SaveAll(l:setting_names)
 


### PR DESCRIPTION
This is necessary to support colorschemes with both light and dark versions, such as solarized.

I tested this with the solarized scheme.  I can reproduce #6 at `HEAD`, and this PR fixes it.
