### PR TITLE
Set t_Co to 256 for HTML output

### DIFF
--- a/autoload/syncopate.vim
+++ b/autoload/syncopate.vim
@@ -25,7 +25,7 @@ function! s:SyncopateSaveAndChangeSettings()
       \ s:plugin.Flag('change_colorscheme'))
 
   " Save any settings we'll need to restore later.
-  let l:setting_names = ['g:html_use_css']
+  let l:setting_names = ['&t_Co', 'g:html_use_css']
   if l:change_colorscheme
     call extend(l:setting_names, ['&background', 'g:colors_name'])
   endif
@@ -35,6 +35,11 @@ function! s:SyncopateSaveAndChangeSettings()
   " <font> tags, but it's necessary to make sure the HTML shows up correctly in
   " email clients (which usually strip out <style> sections).
   let g:html_use_css = 0
+
+  " Set the number of terminal colours to 256.  For vim (as opposed to gvim),
+  " this prevents us from outputting really hideous/unreadable colors for HTML
+  " (which should always have 256 colours available).
+  set t_Co=256
 
   " Choose a more readable colorscheme for the HTML output, if desired.
   if l:change_colorscheme


### PR DESCRIPTION
I can now reproduce the problem if I run vim, and `:set t_Co=8` before I do `:SyncopateExportToBrowser`.

The solution is pretty simple: just add `&t_Co` to the list of settings to save, and force it to 256.  This value only applies for HTML output; it doesn't make sense to constrain the HTML colours we can use for an HTML page.

I verified that this commit makes the problem go away.
