### PR TITLE
Add 'clear_bg' flag to output cleared bg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Current changes
+
+## Features
+
+* New `clear_bg` flag lets `:SyncopateExportToClipboard` output transparent backgrounds.
+
 # 0.2.0
 
 *2014-12-08*

--- a/autoload/syncopate.vim
+++ b/autoload/syncopate.vim
@@ -162,16 +162,20 @@ endfunction
 
 " Put a <div> inside the <body>, with the bgcolor and text attributes (if any)
 " turned into a style attribute.
-" 
+"
 " This is intended to piggyback on 2html.vim's guesses for foreground and
 " background colours.
 function! s:PutDivInBody()
+  " Should this <div> set a background colour, or not?
+  let l:clear_bg = maktaba#ensure#IsBool(s:plugin.Flag('clear_bg'))
+
   " Find the <body>-line, and follow it up with a similar <div>-line.
   1
   call search('<body')
   put =substitute(getline('.'), 'body', 'div', '')
   call s:ReplaceOnCurrentLine('text=\"\(#......\)\"', 'color: \1;')
-  call s:ReplaceOnCurrentLine('bgcolor=\"\(#......\)\"', 'background-color: \1;')
+  let l:bg_replacement = l:clear_bg ? '' : 'background-color: \1;'
+  call s:ReplaceOnCurrentLine('bgcolor=\"\(#......\)\"', l:bg_replacement)
   call s:ReplaceOnCurrentLine('<div \(.*\)>', '<div style=\"\1\">')
 
   " Find the </body>-line, and precede it with a similar </div>-line.

--- a/doc/syncopate.txt
+++ b/doc/syncopate.txt
@@ -78,6 +78,15 @@ don't want to do this (or if you're not using a Debian-based system), you will
 need to set this flag for the browser export to work.
 Default: 'sensible-browser' `
 
+                                                          *syncopate:clear_bg*
+Controls whether |:SyncopateExportToClipboard| will clear the background
+colour.
+
+This can be useful for copy-pasting into a destination (e.g., some talk
+slides) whose background colour might be slightly different than the
+background in the editor.
+Default: 0 `
+
                                                   *syncopate:plugin[commands]*
 Configures whether plugin/commands.vim should be loaded.
 Default: 1 `

--- a/instant/flags.vim
+++ b/instant/flags.vim
@@ -82,3 +82,13 @@ call s:plugin.Flag('colorscheme', 'default')
 " don't want to do this (or if you're not using a Debian-based system), you will
 " need to set this flag for the browser export to work.
 call s:plugin.Flag('browser', 'sensible-browser')
+
+
+""
+" Controls whether @command(SyncopateExportToClipboard) will clear the
+" background colour.
+"
+" This can be useful for copy-pasting into a destination (e.g., some talk
+" slides) whose background colour might be slightly different than the
+" background in the editor.
+call s:plugin.Flag('clear_bg', 0)


### PR DESCRIPTION
As #26 says, this saves us from having to match the background colour exactly.  But when I was testing, I found out there's another use case: _gradient_ backgrounds, which can't be matched by _any_ single colour.  This flag definitely improves the output in all those cases.
